### PR TITLE
feat: Implemented height-based protection for claims + PT-BR translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
+# 1.0.11
+* Added height-based protection control - blocks below a configurable minimum Y coordinate are not protected (default: 0, can be any integer value)
+* Added admin command `/scp admin-set-min-height <height>` to configure minimum protection height
+* Added Portuguese (Brazil) language support (pt-BR)
+
 # 1.0.10
 
 * Fixed Map Ticking task running off thread when checking for components, closes #18
-* Added height-based protection control - blocks below a configurable minimum Y coordinate are not protected (default: -20, can be any integer value)
-* Added admin command `/scp admin-set-min-height <height>` to configure minimum protection height
-* Added Portuguese (Brazil) language support (pt-BR)
 
 # 1.0.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 1.0.10
 
 * Fixed Map Ticking task running off thread when checking for components, closes #18
+* Added height-based protection control - blocks below a configurable minimum Y coordinate are not protected (default: -20, can be any integer value)
+* Added admin command `/scp admin-set-min-height <height>` to configure minimum protection height
+* Added Portuguese (Brazil) language support (pt-BR)
 
 # 1.0.9
 

--- a/src/main/java/com/buuz135/simpleclaims/claim/InteractionResult.java
+++ b/src/main/java/com/buuz135/simpleclaims/claim/InteractionResult.java
@@ -1,0 +1,43 @@
+package com.buuz135.simpleclaims.claim;
+
+public class InteractionResult {
+    private final boolean allowed;
+    private final boolean blockedByHeight;
+    private final int blockY;
+    private final int minHeight;
+
+    private InteractionResult(boolean allowed, boolean blockedByHeight, int blockY, int minHeight) {
+        this.allowed = allowed;
+        this.blockedByHeight = blockedByHeight;
+        this.blockY = blockY;
+        this.minHeight = minHeight;
+    }
+
+    public static InteractionResult allowed() {
+        return new InteractionResult(true, false, 0, 0);
+    }
+
+    public static InteractionResult blockedByHeight(int blockY, int minHeight) {
+        return new InteractionResult(false, true, blockY, minHeight);
+    }
+
+    public static InteractionResult blockedByPermission() {
+        return new InteractionResult(false, false, 0, 0);
+    }
+
+    public boolean isAllowed() {
+        return allowed;
+    }
+
+    public boolean isBlockedByHeight() {
+        return blockedByHeight;
+    }
+
+    public int getBlockY() {
+        return blockY;
+    }
+
+    public int getMinHeight() {
+        return minHeight;
+    }
+}

--- a/src/main/java/com/buuz135/simpleclaims/commands/CommandMessages.java
+++ b/src/main/java/com/buuz135/simpleclaims/commands/CommandMessages.java
@@ -43,4 +43,8 @@ public class CommandMessages {
 
     public static final Message ENABLED_OVERRIDE = Message.translation("commands.simpleclaims.enabledOverride").color(Color.GREEN).bold(true);
     public static final Message DISABLED_OVERRIDE = Message.translation("commands.simpleclaims.disabledOverride").color(Color.GREEN).bold(true);
+
+    public static final Message MODIFIED_MIN_PROTECTION_HEIGHT = Message.translation("commands.simpleclaims.modifiedMinProtectionHeight").color(Color.GREEN).bold(true);
+
+    public static final Message BLOCKED_BY_HEIGHT = Message.translation("commands.errors.simpleclaims.blockedByHeight").color(Color.RED).bold(true);
 }

--- a/src/main/java/com/buuz135/simpleclaims/commands/SimpleClaimsPartyCommand.java
+++ b/src/main/java/com/buuz135/simpleclaims/commands/SimpleClaimsPartyCommand.java
@@ -9,6 +9,7 @@ import com.buuz135.simpleclaims.commands.subcommand.party.op.OpCreatePartyComman
 import com.buuz135.simpleclaims.commands.subcommand.party.op.OpModifyChunkAmountCommand;
 import com.buuz135.simpleclaims.commands.subcommand.party.op.OpOverrideCommand;
 import com.buuz135.simpleclaims.commands.subcommand.party.op.OpPartyListCommand;
+import com.buuz135.simpleclaims.commands.subcommand.party.op.OpSetMinHeightCommand;
 import com.buuz135.simpleclaims.gui.PartyInfoEditGui;
 import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
@@ -42,6 +43,7 @@ public class SimpleClaimsPartyCommand extends AbstractAsyncCommand {
         this.addSubCommand(new OpPartyListCommand());
         this.addSubCommand(new OpModifyChunkAmountCommand());
         this.addSubCommand(new OpOverrideCommand());
+        this.addSubCommand(new OpSetMinHeightCommand());
     }
 
     @NonNullDecl

--- a/src/main/java/com/buuz135/simpleclaims/commands/subcommand/party/op/OpSetMinHeightCommand.java
+++ b/src/main/java/com/buuz135/simpleclaims/commands/subcommand/party/op/OpSetMinHeightCommand.java
@@ -1,0 +1,59 @@
+package com.buuz135.simpleclaims.commands.subcommand.party.op;
+
+import com.buuz135.simpleclaims.Main;
+import com.buuz135.simpleclaims.commands.CommandMessages;
+import com.hypixel.hytale.component.Ref;
+import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.protocol.GameMode;
+import com.hypixel.hytale.server.core.command.system.CommandContext;
+import com.hypixel.hytale.server.core.command.system.CommandSender;
+import com.hypixel.hytale.server.core.command.system.arguments.system.RequiredArg;
+import com.hypixel.hytale.server.core.command.system.arguments.types.ArgTypes;
+import com.hypixel.hytale.server.core.command.system.basecommands.AbstractAsyncCommand;
+import com.hypixel.hytale.server.core.entity.entities.Player;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+import com.hypixel.hytale.server.core.universe.world.World;
+import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+import org.checkerframework.checker.nullness.compatqual.NonNullDecl;
+
+import java.util.concurrent.CompletableFuture;
+
+import static com.hypixel.hytale.server.core.command.commands.player.inventory.InventorySeeCommand.MESSAGE_COMMANDS_ERRORS_PLAYER_NOT_IN_WORLD;
+
+public class OpSetMinHeightCommand extends AbstractAsyncCommand {
+
+    private RequiredArg<Integer> height;
+
+    public OpSetMinHeightCommand() {
+        super("admin-set-min-height", "Sets the minimum protection height for claims");
+        this.setPermissionGroup(GameMode.Creative);
+        this.height = this.withRequiredArg("height", "The minimum Y coordinate where blocks will be protected", ArgTypes.INTEGER);
+    }
+
+    @NonNullDecl
+    @Override
+    protected CompletableFuture<Void> executeAsync(CommandContext commandContext) {
+        CommandSender sender = commandContext.sender();
+        if (sender instanceof Player player) {
+            Ref<EntityStore> ref = player.getReference();
+            if (ref != null && ref.isValid()) {
+                Store<EntityStore> store = ref.getStore();
+                World world = store.getExternalData().getWorld();
+                return CompletableFuture.runAsync(() -> {
+                    PlayerRef playerRef = store.getComponent(ref, PlayerRef.getComponentType());
+                    if (playerRef != null) {
+                        var selectedHeight = height.get(commandContext);
+                        Main.CONFIG.get().setMinProtectionHeight(selectedHeight);
+                        Main.CONFIG.save();
+                        player.sendMessage(CommandMessages.MODIFIED_MIN_PROTECTION_HEIGHT.param("height", selectedHeight));
+                    }
+                }, world);
+            } else {
+                commandContext.sendMessage(MESSAGE_COMMANDS_ERRORS_PLAYER_NOT_IN_WORLD);
+                return CompletableFuture.completedFuture(null);
+            }
+        } else {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+}

--- a/src/main/java/com/buuz135/simpleclaims/config/SimpleClaimsConfig.java
+++ b/src/main/java/com/buuz135/simpleclaims/config/SimpleClaimsConfig.java
@@ -28,6 +28,9 @@ public class SimpleClaimsConfig {
             .append(new KeyedCodec<Boolean>("DefaultPartyPVPEnabled", Codec.BOOLEAN),
                     (simpleClaimsConfig, value, extraInfo) -> simpleClaimsConfig.DefaultPartyPVPEnabled = value,
                     (simpleClaimsConfig, extraInfo) -> simpleClaimsConfig.DefaultPartyPVPEnabled).add()
+            .append(new KeyedCodec<Integer>("MinProtectionHeight", Codec.INTEGER),
+                    (simpleClaimsConfig, value, extraInfo) -> simpleClaimsConfig.MinProtectionHeight = value,
+                    (simpleClaimsConfig, extraInfo) -> simpleClaimsConfig.MinProtectionHeight).add()
             .build();
 
     private int DefaultPartyClaimsAmount = 25;
@@ -38,6 +41,8 @@ public class SimpleClaimsConfig {
 
     private boolean ForceSimpleClaimsChunkWorldMap = true;
     private boolean CreativeModeBypassProtection = false;
+    // 0 = Entire chunk is protected
+    private int MinProtectionHeight = 0;
 
     public SimpleClaimsConfig() {
 
@@ -69,5 +74,13 @@ public class SimpleClaimsConfig {
 
     public boolean isDefaultPartyPVPEnabled() {
         return DefaultPartyPVPEnabled;
+    }
+
+    public int getMinProtectionHeight() {
+        return MinProtectionHeight;
+    }
+
+    public void setMinProtectionHeight(int minProtectionHeight) {
+        MinProtectionHeight = minProtectionHeight;
     }
 }

--- a/src/main/java/com/buuz135/simpleclaims/systems/events/BreakBlockEventSystem.java
+++ b/src/main/java/com/buuz135/simpleclaims/systems/events/BreakBlockEventSystem.java
@@ -34,8 +34,14 @@ public class BreakBlockEventSystem extends EntityEventSystem<EntityStore, BreakB
        Ref<EntityStore> ref = archetypeChunk.getReferenceTo(index);
        Player player = store.getComponent(ref, Player.getComponentType());
         PlayerRef playerRef = store.getComponent(ref, PlayerRef.getComponentType());
-        if (playerRef != null && !ClaimManager.getInstance().isAllowedToInteract(playerRef.getUuid(), player.getWorld().getName(), event.getTargetBlock().getX(), event.getTargetBlock().getZ(), PartyInfo::isBlockBreakEnabled)) {
-           event.setCancelled(true);
+        if (playerRef != null) {
+            var result = ClaimManager.getInstance().checkInteraction(playerRef.getUuid(), player.getWorld().getName(), event.getTargetBlock().getX(), event.getTargetBlock().getZ(), event.getTargetBlock().getY(), PartyInfo::isBlockBreakEnabled);
+            if (!result.isAllowed()) {
+                event.setCancelled(true);
+                if (result.isBlockedByHeight()) {
+                    player.sendMessage(com.buuz135.simpleclaims.commands.CommandMessages.BLOCKED_BY_HEIGHT.param("blockY", result.getBlockY()).param("minHeight", result.getMinHeight()));
+                }
+            }
        }
     }
 

--- a/src/main/java/com/buuz135/simpleclaims/systems/events/CustomDamageEventSystem.java
+++ b/src/main/java/com/buuz135/simpleclaims/systems/events/CustomDamageEventSystem.java
@@ -40,12 +40,15 @@ public class CustomDamageEventSystem extends DamageEventSystem {
             if (attackerRef.isValid()) {
                 Player attackerPlayerComponent = (Player) commandBuffer.getComponent(attackerRef, Player.getComponentType());
                 if (attackerPlayerComponent != null) { //The source is a player
-                    // && !ClaimManager.getInstance().isAllowedToInteract(playerRef.getUuid(), player.getWorld().getName(), (int) transform.getX(), (int) transform.getZ(), PartyInfo::isPVPEnabled)) {
-                    var chunk = ClaimManager.getInstance().getChunkRawCoords(player.getWorld().getName(), (int) transform.getX(), (int) transform.getZ());
-                    if (chunk == null) return;
-                    var partyInfo = ClaimManager.getInstance().getPartyById(chunk.getPartyOwner());
-                    if (partyInfo != null && !partyInfo.isPVPEnabled()) {
-                        damage.setCancelled(true);
+                    int blockY = (int) transform.getY();
+                    int minHeight = com.buuz135.simpleclaims.Main.CONFIG.get().getMinProtectionHeight();
+                    if (blockY >= minHeight) {
+                        var chunk = ClaimManager.getInstance().getChunkRawCoords(player.getWorld().getName(), (int) transform.getX(), (int) transform.getZ());
+                        if (chunk == null) return;
+                        var partyInfo = ClaimManager.getInstance().getPartyById(chunk.getPartyOwner());
+                        if (partyInfo != null && !partyInfo.isPVPEnabled()) {
+                            damage.setCancelled(true);
+                        }
                     }
                 }
             }

--- a/src/main/java/com/buuz135/simpleclaims/systems/events/InteractEventSystem.java
+++ b/src/main/java/com/buuz135/simpleclaims/systems/events/InteractEventSystem.java
@@ -36,8 +36,14 @@ public class InteractEventSystem extends EntityEventSystem<EntityStore, UseBlock
        Ref<EntityStore> ref = archetypeChunk.getReferenceTo(index);
        Player player = store.getComponent(ref, Player.getComponentType());
         PlayerRef playerRef = store.getComponent(ref, PlayerRef.getComponentType());
-        if (playerRef != null && !ClaimManager.getInstance().isAllowedToInteract(playerRef.getUuid(), player.getWorld().getName(), event.getTargetBlock().getX(), event.getTargetBlock().getZ(), PartyInfo::isBlockInteractEnabled)) {
-           event.setCancelled(true);
+        if (playerRef != null) {
+            var result = ClaimManager.getInstance().checkInteraction(playerRef.getUuid(), player.getWorld().getName(), event.getTargetBlock().getX(), event.getTargetBlock().getZ(), event.getTargetBlock().getY(), PartyInfo::isBlockInteractEnabled);
+            if (!result.isAllowed()) {
+                event.setCancelled(true);
+                if (result.isBlockedByHeight()) {
+                    player.sendMessage(com.buuz135.simpleclaims.commands.CommandMessages.BLOCKED_BY_HEIGHT.param("blockY", result.getBlockY()).param("minHeight", result.getMinHeight()));
+                }
+            }
        }
     }
 

--- a/src/main/java/com/buuz135/simpleclaims/systems/events/PickupInteractEventSystem.java
+++ b/src/main/java/com/buuz135/simpleclaims/systems/events/PickupInteractEventSystem.java
@@ -33,13 +33,20 @@ public class PickupInteractEventSystem extends EntityEventSystem<EntityStore, In
         Ref<EntityStore> ref = archetypeChunk.getReferenceTo(index);
         Player player = store.getComponent(ref, Player.getComponentType());
         PlayerRef playerRef = store.getComponent(ref, PlayerRef.getComponentType());
-        if (playerRef != null && !ClaimManager.getInstance().isAllowedToInteract(
-                playerRef.getUuid(),
-                player.getWorld().getName(),
-                (int) playerRef.getTransform().getPosition().getX(),
-                (int) playerRef.getTransform().getPosition().getZ(),
-                PartyInfo::isBlockInteractEnabled)) {
-            event.setCancelled(true); // Doesnt currently work, it gets ignored
+        if (playerRef != null) {
+            var result = ClaimManager.getInstance().checkInteraction(
+                    playerRef.getUuid(),
+                    player.getWorld().getName(),
+                    (int) playerRef.getTransform().getPosition().getX(),
+                    (int) playerRef.getTransform().getPosition().getZ(),
+                    (int) playerRef.getTransform().getPosition().getY(),
+                    PartyInfo::isBlockInteractEnabled);
+            if (!result.isAllowed()) {
+                event.setCancelled(true); // Doesnt currently work, it gets ignored
+                if (result.isBlockedByHeight()) {
+                    player.sendMessage(com.buuz135.simpleclaims.commands.CommandMessages.BLOCKED_BY_HEIGHT.param("blockY", result.getBlockY()).param("minHeight", result.getMinHeight()));
+                }
+            }
         }
     }
 

--- a/src/main/java/com/buuz135/simpleclaims/systems/events/PlaceBlockEventSystem.java
+++ b/src/main/java/com/buuz135/simpleclaims/systems/events/PlaceBlockEventSystem.java
@@ -33,8 +33,14 @@ public class PlaceBlockEventSystem extends EntityEventSystem<EntityStore, PlaceB
        Ref<EntityStore> ref = archetypeChunk.getReferenceTo(index);
        Player player = store.getComponent(ref, Player.getComponentType());
         PlayerRef playerRef = store.getComponent(ref, PlayerRef.getComponentType());
-        if (playerRef != null && !ClaimManager.getInstance().isAllowedToInteract(playerRef.getUuid(), player.getWorld().getName(), event.getTargetBlock().getX(), event.getTargetBlock().getZ(), PartyInfo::isBlockPlaceEnabled)) {
-           event.setCancelled(true);
+        if (playerRef != null) {
+            var result = ClaimManager.getInstance().checkInteraction(playerRef.getUuid(), player.getWorld().getName(), event.getTargetBlock().getX(), event.getTargetBlock().getZ(), event.getTargetBlock().getY(), PartyInfo::isBlockPlaceEnabled);
+            if (!result.isAllowed()) {
+                event.setCancelled(true);
+                if (result.isBlockedByHeight()) {
+                    player.sendMessage(com.buuz135.simpleclaims.commands.CommandMessages.BLOCKED_BY_HEIGHT.param("blockY", result.getBlockY()).param("minHeight", result.getMinHeight()));
+                }
+            }
        }
     }
 

--- a/src/main/resources/Server/Languages/en-US/commands.lang
+++ b/src/main/resources/Server/Languages/en-US/commands.lang
@@ -27,3 +27,5 @@ simpleclaims.partyOwnerTransferred = You have left your party, and the ownership
 simpleclaims.modifiedMaxChunkAmount = You have changed the max claimed chunk amount for {party_name} to {amount} chunks
 simpleclaims.enabledOverride = Enabled admin interaction override
 simpleclaims.disabledOverride = Disabled admin interaction override
+simpleclaims.modifiedMinProtectionHeight = Minimum protection height set to {height}. Blocks below this Y coordinate will not be protected.
+errors.simpleclaims.blockedByHeight = This block at Y={blockY} is protected. Only blocks at Y<{minHeight} can be interacted with by anyone.

--- a/src/main/resources/Server/Languages/pt-BR/commands.lang
+++ b/src/main/resources/Server/Languages/pt-BR/commands.lang
@@ -1,0 +1,31 @@
+errors.simpleclaims.playerNotInParty = Você precisa estar em um grupo para fazer isso
+errors.simpleclaims.playerInParty = Você já está em um grupo
+
+errors.simpleclaims.alreadyClaimedByYou = Este chunk já foi reivindicado pelo seu grupo
+errors.simpleclaims.alreadyClaimedByAnotherPlayer = Este chunk já foi reivindicado por outro grupo
+errors.simpleclaims.notClaimed = Este chunk não foi reivindicado
+errors.simpleclaims.notYourClaim = Este chunk não pertence ao seu grupo
+errors.simpleclaims.notEnoughChunks = Seu grupo não tem chunks suficientes para reivindicar isso
+errors.simpleclaims.playerNotFound = Jogador não encontrado
+errors.simpleclaims.cantClaimInThisDimension = Você não pode reivindicar chunks nesta dimensão
+
+simpleclaims.partyCreated = Grupo Criado
+info.simpleclaims.unclaimed = Chunk não reivindicado
+info.simpleclaims.claimed = Chunk reivindicado
+simpleclaims.nowUsingParty = Agora usando grupo: 
+
+errors.simpleclaims.admin.partyNotSelected = Grupo não selecionado como admin
+errors.simpleclaims.admin.partyNotFound = Grupo não encontrado
+
+simpleclaims.partyInviteSent = Convite de grupo enviado para {username}
+simpleclaims.partyInviteReceived = Convite de grupo recebido de {username} para entrar no grupo {party_name}, use o comando '/scp invite-accept' para entrar no grupo.
+simpleclaims.partyInviteJoined = {username} entrou no grupo {party_name}
+simpleclaims.partyInviteSelf = Este jogador já é membro do grupo
+simpleclaims.partyLeft = Você saiu do seu grupo
+simpleclaims.partyDisbanded = Você saiu do seu grupo, como não há mais membros, o grupo foi desfeito
+simpleclaims.partyOwnerTransferred = Você saiu do seu grupo, e a propriedade foi transferida para {username}
+simpleclaims.modifiedMaxChunkAmount = Você alterou a quantidade máxima de chunks reivindicados para {party_name} para {amount} chunks
+simpleclaims.enabledOverride = Override de interação de admin ativado
+simpleclaims.disabledOverride = Override de interação de admin desativado
+simpleclaims.modifiedMinProtectionHeight = Altura mínima de proteção definida para {height}. Blocos abaixo desta coordenada Y não serão protegidos.
+errors.simpleclaims.blockedByHeight = Este bloco em Y={blockY} está protegido. Apenas blocos em Y<{minHeight} podem ser interagidos por qualquer jogador.

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,11 +1,14 @@
 {
   "Group": "Buuz135",
   "Name": "SimpleClaims",
-  "Version": "1.0.10",
+  "Version": "1.0.11",
   "Description": "A chunk claiming and protection mod. Create parties, claim chunks, and protect your builds from other players.",
   "Authors": [
     {
       "Name": "Buuz135"
+    },
+    {
+      "Name": "Goul4rt"
     }
   ],
   "Website": "${website}",


### PR DESCRIPTION
This PR implements height-based protection for claimed chunks, allowing server administrators to configure a minimum Y coordinate below which blocks are not protected. This feature enables more flexible claim protection, particularly useful for allowing public access to underground areas while maintaining protection for surface structures.

### Core Features
- **Height-based protection**: Blocks below a configurable minimum Y coordinate are not protected by claims
- **Admin command**: Added `/scp admin-set-min-height <height>` command to configure the minimum protection height
- **Default value**: Minimum protection height defaults to `0` (entire chunk protected by default)

### Implementation Details

#### New Components
- **`InteractionResult` class**: New result type that distinguishes between permission-based blocks and height-based blocks, providing better error messaging
- **Configuration option**: Added `MinProtectionHeight` to `SimpleClaimsConfig` with getter/setter methods

#### Updated Systems
All event systems have been updated to respect the minimum protection height:
- `BreakBlockEventSystem` - Block breaking protection
- `PlaceBlockEventSystem` - Block placement protection  
- `InteractEventSystem` - Block interaction protection
- `PickupInteractEventSystem` - Item pickup protection
- `CustomDamageEventSystem` - PVP damage protection

### Admin Command
```
/scp admin-set-min-height <height>
```

Sets the minimum Y coordinate where blocks will be protected. Blocks below this height are not protected by claims.

**Examples:**
- `/scp admin-set-min-height -20` - Only protect blocks at Y >= -20
- `/scp admin-set-min-height 0` - Protect entire chunk (default)
- `/scp admin-set-min-height 64` - Only protect blocks above sea level

### Behavior
- When a player tries to interact with a block at Y >= `MinProtectionHeight` in a claimed chunk, normal claim protection applies
- When a player tries to interact with a block at Y < `MinProtectionHeight`, the interaction is allowed regardless of claim status
- Players receive clear error messages indicating when a block is protected due to height restrictions
