### PR TITLE
Fix interaction logic to require ignored flag for block interactions

### DIFF
--- a/src/main/java/com/buuz135/simpleclaims/interactions/ClaimUseBlockInteraction.java
+++ b/src/main/java/com/buuz135/simpleclaims/interactions/ClaimUseBlockInteraction.java
@@ -58,7 +58,7 @@ public class ClaimUseBlockInteraction extends UseBlockInteraction {
             defaultInteract = PartyInfo::isChairInteractEnabled;
         else if (blockName.contains("portal") || blockName.contains("teleporter"))
             defaultInteract = PartyInfo::isPortalInteractEnabled;
-        if (!ignored && (playerRef != null && ClaimManager.getInstance().isAllowedToInteract(playerRef.getUuid(), player.getWorld().getName(), targetBlock.getX(), targetBlock.getZ(), defaultInteract))) {
+        if (ignored || (playerRef != null && ClaimManager.getInstance().isAllowedToInteract(playerRef.getUuid(), player.getWorld().getName(), targetBlock.getX(), targetBlock.getZ(), defaultInteract))) {
             super.interactWithBlock(world, commandBuffer, type, context, itemInHand, targetBlock, cooldownHandler);
         }
     }
@@ -85,7 +85,7 @@ public class ClaimUseBlockInteraction extends UseBlockInteraction {
             defaultInteract = PartyInfo::isChairInteractEnabled;
         else if (blockName.contains("portal") || blockName.contains("teleporter"))
             defaultInteract = PartyInfo::isPortalInteractEnabled;
-        if (!ignored && (playerRef != null && ClaimManager.getInstance().isAllowedToInteract(playerRef.getUuid(), player.getWorld().getName(), targetBlock.getX(), targetBlock.getZ(), defaultInteract))) {
+        if (ignored || (playerRef != null && ClaimManager.getInstance().isAllowedToInteract(playerRef.getUuid(), player.getWorld().getName(), targetBlock.getX(), targetBlock.getZ(), defaultInteract))) {
             super.simulateInteractWithBlock(type, context, itemInHand, world, targetBlock);
         }
     }

--- a/src/main/java/com/buuz135/simpleclaims/systems/events/InteractEventSystem.java
+++ b/src/main/java/com/buuz135/simpleclaims/systems/events/InteractEventSystem.java
@@ -52,7 +52,7 @@ public class InteractEventSystem extends EntityEventSystem<EntityStore, UseBlock
             defaultInteract = PartyInfo::isChairInteractEnabled;
         else if (blockName.contains("portal") || blockName.contains("teleporter"))
             defaultInteract = PartyInfo::isPortalInteractEnabled;
-        if (ignored || (playerRef != null && !ClaimManager.getInstance().isAllowedToInteract(playerRef.getUuid(), player.getWorld().getName(), event.getTargetBlock().getX(), event.getTargetBlock().getZ(), defaultInteract))) {
+        if (!ignored && (playerRef != null && !ClaimManager.getInstance().isAllowedToInteract(playerRef.getUuid(), player.getWorld().getName(), event.getTargetBlock().getX(), event.getTargetBlock().getZ(), defaultInteract))) {
             event.setCancelled(true);
         }
     }


### PR DESCRIPTION
As seen on Discord, I'm proposing this PR to correct an unexpected behavior.

The interaction is cancelled with your code :

please, replace `if (ignored || (playerRef...` by `if (!ignored && (playerRef...`

Unless it's intentional, it cancels the events of the items/blocks that we add in the mod's configuration.